### PR TITLE
deps: update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
   },
   "devDependencies": {
     "chai": "^2.1.0",
-    "lodash": "^3.3.1",
     "mocha": "^2.0.0",
-    "strong-pubsub": "^0.2.5",
-    "strong-pubsub-test": "^0.2.1"
+    "strong-pubsub": "^0.2.0",
+    "strong-pubsub-test": "^0.2.0"
   }
 }


### PR DESCRIPTION
Use published versions of strong-pubsub-\* and remove redundant lodash
dev dep.

Connect to strongloop-internal/scrum-nodeops#901

Closes #1 
